### PR TITLE
mod.pk

### DIFF
--- a/ble_app_uart_c/ble_uart_c.c
+++ b/ble_app_uart_c/ble_uart_c.c
@@ -189,7 +189,7 @@ static void db_discover_evt_handler(ble_db_discovery_evt_t * p_evt)
 
         ble_uart_c_evt_t evt;
 
-        evt.evt_type = BLE_uart_C_EVT_DISCOVERY_COMPLETE;
+        evt.evt_type = BLE_UART_C_EVT_DISCOVERY_COMPLETE;
 
         mp_ble_uart_c->evt_handler(mp_ble_uart_c, &evt);
     }

--- a/ble_app_uart_c/ble_uart_c.c
+++ b/ble_app_uart_c/ble_uart_c.c
@@ -130,7 +130,7 @@ static void on_hvx(ble_uart_c_t * p_ble_uart_c, const ble_evt_t * p_ble_evt)
     {
         ble_uart_c_evt_t ble_uart_c_evt;
 
-        ble_uart_c_evt.evt_type = BLE_UART_C_EVT_HRM_NOTIFICATION;
+        ble_uart_c_evt.evt_type = BLE_UART_C_EVT_RX_DATA_NOTIFICATION;
 				memcpy(ble_uart_c_evt.params.uart.rx_data,p_ble_evt->evt.gattc_evt.params.hvx.data,p_ble_evt->evt.gattc_evt.params.hvx.len);
 				ble_uart_c_evt.params.uart.len = p_ble_evt->evt.gattc_evt.params.hvx.len;
         p_ble_uart_c->evt_handler(p_ble_uart_c, &ble_uart_c_evt);

--- a/ble_app_uart_c/ble_uart_c.c
+++ b/ble_app_uart_c/ble_uart_c.c
@@ -26,8 +26,6 @@
 
 #define LOG                    app_trace_log         /**< Debug logger macro that will be used in this file to do logging of important information over UART. */
 
-#define HRM_FLAG_MASK_HR_16BIT (0x01 << 0)           /**< Bit mask used to extract the type of heart rate value. This is used to find if the received heart rate is a 16 bit value or an 8 bit value. */
-
 #define TX_BUFFER_MASK         0x07                  /**< TX Buffer mask, must be a mask of continuous zeroes, followed by continuous sequence of ones: 000...111. */
 #define TX_BUFFER_SIZE         (TX_BUFFER_MASK + 1)  /**< Size of send buffer, which is 1 higher than the mask. */
 
@@ -116,16 +114,15 @@ static void on_write_rsp(ble_uart_c_t * p_ble_uart_c, const ble_evt_t * p_ble_ev
 /**@brief     Function for handling Handle Value Notification received from the SoftDevice.
  *
  * @details   This function will uses the Handle Value Notification received from the SoftDevice
- *            and checks if it is a notification of the heart rate measurement from the peer. If
- *            it is, this function will decode the heart rate measurement and send it to the
- *            application.
+ *            and checks if it is a notification of the NUS RX data from the peer. If it is,
+ *            this function will send the RX data to the application.
  *
- * @param[in] p_ble_uart_c Pointer to the Heart Rate Client structure.
+ * @param[in] p_ble_uart_c Pointer to the NUS Client structure.
  * @param[in] p_ble_evt   Pointer to the BLE event received.
  */
 static void on_hvx(ble_uart_c_t * p_ble_uart_c, const ble_evt_t * p_ble_evt)
 {
-    // Check if this is a heart rate notification.
+    // Check if this is an RX data notification.
     if (p_ble_evt->evt.gattc_evt.params.hvx.handle == p_ble_uart_c->RX_handle)
     {
         ble_uart_c_evt_t ble_uart_c_evt;
@@ -141,8 +138,8 @@ static void on_hvx(ble_uart_c_t * p_ble_uart_c, const ble_evt_t * p_ble_evt)
 /**@brief     Function for handling events from the database discovery module.
  *
  * @details   This function will handle an event from the database discovery module, and determine
- *            if it relates to the discovery of heart rate service at the peer. If so, it will
- *            call the application's event handler indicating that the heart rate service has been
+ *            if it relates to the discovery of nordic uart service at the peer. If so, it will
+ *            call the application's event handler indicating that the nordic uart service has been
  *            discovered at the peer. It also populates the event with the service related
  *            information before providing it to the application.
  *
@@ -151,14 +148,14 @@ static void on_hvx(ble_uart_c_t * p_ble_uart_c, const ble_evt_t * p_ble_evt)
  */
 static void db_discover_evt_handler(ble_db_discovery_evt_t * p_evt)
 {
-    // Check if the Heart Rate Service was discovered.
+    // Check if the Nordic UART Service was discovered.
     if (p_evt->evt_type == BLE_DB_DISCOVERY_COMPLETE &&
         p_evt->params.discovered_db.srv_uuid.uuid == BLE_UUID_NUS_SERVICE &&
         p_evt->params.discovered_db.srv_uuid.type == uart_uuid.type)
     {
         mp_ble_uart_c->conn_handle = p_evt->conn_handle;
 
-        // Find the CCCD Handle of the Heart Rate Measurement characteristic.
+        // Find the CCCD Handles of the TX/RX data characteristics.
         uint32_t i;
 
         for (i = 0; i < p_evt->params.discovered_db.char_count; i++)
@@ -167,7 +164,7 @@ static void db_discover_evt_handler(ble_db_discovery_evt_t * p_evt)
             	&&(p_evt->params.discovered_db.charateristics[i].characteristic.uuid.type==uart_uuid.type))
                 
             {
-                // Found Heart Rate characteristic. Store CCCD handle .
+                // Found RX data characteristic. Store CCCD handle .
                 mp_ble_uart_c->RX_cccd_handle =
                     p_evt->params.discovered_db.charateristics[i].cccd_handle;
                 mp_ble_uart_c->RX_handle      =
@@ -177,7 +174,7 @@ static void db_discover_evt_handler(ble_db_discovery_evt_t * p_evt)
 		if ((p_evt->params.discovered_db.charateristics[i].characteristic.uuid.uuid == BLE_UUID_NUS_TX_CHARACTERISTIC)
 			&&(p_evt->params.discovered_db.charateristics[i].characteristic.uuid.type==uart_uuid.type))
             {
-                // Found Heart Rate characteristic. Store CCCD handle .
+                // Found TX data characteristic. Store CCCD handle .
                 mp_ble_uart_c->TX_handle      =
                     p_evt->params.discovered_db.charateristics[i].characteristic.handle_value;
                
@@ -185,7 +182,7 @@ static void db_discover_evt_handler(ble_db_discovery_evt_t * p_evt)
 						
         }
 
-        LOG("[uart_C]: Heart Rate Service discovered at peer.\r\n");
+        LOG("[uart_C]: Nordic UART service (NUS) discovered at peer.\r\n");
 
         ble_uart_c_evt_t evt;
 

--- a/ble_app_uart_c/ble_uart_c.c
+++ b/ble_app_uart_c/ble_uart_c.c
@@ -315,7 +315,7 @@ static uint32_t cccd_configure(uint16_t conn_handle, uint16_t handle_cccd, bool 
         return NRF_ERROR_INVALID_STATE;
     }
     LOG("[uart_C]: Writing to characteristic Handle = %d, Connection Handle = %d\r\n",
-        char_handle,conn_handle);
+        p_ble_uart_c->TX_handle,p_ble_uart_c->conn_handle);
 
     tx_message_t * p_msg;
    

--- a/ble_app_uart_c/ble_uart_c.c
+++ b/ble_app_uart_c/ble_uart_c.c
@@ -310,6 +310,10 @@ static uint32_t cccd_configure(uint16_t conn_handle, uint16_t handle_cccd, bool 
 //}
  uint32_t ble_uart_c_write_string(ble_uart_c_t * p_ble_uart_c, const uint8_t * p_str, uint16_t p_str_len)
  {
+    if (p_ble_uart_c->conn_handle == BLE_CONN_HANDLE_INVALID)
+    {
+        return NRF_ERROR_INVALID_STATE;
+    }
     LOG("[uart_C]: Writing to characteristic Handle = %d, Connection Handle = %d\r\n",
         char_handle,conn_handle);
 

--- a/ble_app_uart_c/ble_uart_c.h
+++ b/ble_app_uart_c/ble_uart_c.h
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef BLE_uart_C_H__
-#define BLE_uart_C_H__
+#ifndef BLE_UART_C_H__
+#define BLE_UART_C_H__
 #define BLE_UUID_NUS_SERVICE            0x0001                       /**< The UUID of the Nordic UART Service. */
 #define BLE_UUID_NUS_TX_CHARACTERISTIC  0x0002                       /**< The UUID of the TX Characteristic. */
 #define BLE_UUID_NUS_RX_CHARACTERISTIC  0x0003                       /**< The UUID of the RX Characteristic. */
@@ -50,7 +50,7 @@
 /**@brief uart Client event type. */
 typedef enum
 {
-    BLE_uart_C_EVT_DISCOVERY_COMPLETE = 1,  /**< Event indicating that the Heart Rate Service has been discovered at the peer. */
+    BLE_UART_C_EVT_DISCOVERY_COMPLETE = 1,  /**< Event indicating that the Heart Rate Service has been discovered at the peer. */
     BLE_UART_C_EVT_HRM_NOTIFICATION         /**< Event indicating that a notification of the Heart Rate Measurement characteristic has been received from the peer. */
 } ble_uart_c_evt_type_t;
 
@@ -186,7 +186,7 @@ uint32_t ble_uart_c_rx_notif_enable(ble_uart_c_t * p_ble_uart_c);
 
 /** @} */ // End tag for Function group.
 
-#endif // BLE_uart_C_H__
+#endif // BLE_UART_C_H__
 
 
 

--- a/ble_app_uart_c/ble_uart_c.h
+++ b/ble_app_uart_c/ble_uart_c.h
@@ -51,7 +51,7 @@
 typedef enum
 {
     BLE_UART_C_EVT_DISCOVERY_COMPLETE = 1,  /**< Event indicating that the Heart Rate Service has been discovered at the peer. */
-    BLE_UART_C_EVT_HRM_NOTIFICATION         /**< Event indicating that a notification of the Heart Rate Measurement characteristic has been received from the peer. */
+    BLE_UART_C_EVT_RX_DATA_NOTIFICATION     /**< Event indicating that a notification of the NUS RX data characteristic has been received from the peer. */
 } ble_uart_c_evt_type_t;
 
 /** @} */

--- a/ble_app_uart_c/ble_uart_c.h
+++ b/ble_app_uart_c/ble_uart_c.h
@@ -9,22 +9,14 @@
 
 /**@file
  *
- * @defgroup ble_sdk_srv_uart_c   Heart Rate Service Client
+ * @defgroup ble_sdk_srv_uart_c   Nordic UART Service (NUS) Client
  * @{
  * @ingroup  ble_sdk_srv
- * @brief    Heart Rate Service Client module.
+ * @brief    Nordic UART Service (NUS) Client module.
  *
- * @details  This module contains the APIs and types exposed by the Heart Rate Service Client
+ * @details  This module contains the APIs and types exposed by the Nordic UART Service (NUS) Client
  *           module. These APIs and types can be used by the application to perform discovery of
- *           Heart Rate Service at the peer and interact with it.
- *
- * @warning  Currently this module only has support for Heart Rate Measurement characteristic. This
- *           means that it will be able to enable notification of the characteristic at the peer and
- *           be able to receive Heart Rate Measurement notifications from the peer. It does not
- *           support the Body Sensor Location and the Heart Rate Control Point characteristics.
- *           When a Heart Rate Measurement is received, this module will decode only the
- *           Heart Rate Measurement Value (both 8 bit and 16 bit) field from it and provide it to
- *           the application.
+ *           Nordic UART Service (NUS) at the peer and interact with it.
  *
  * @note     The application must propagate BLE stack events to this module by calling
  *           ble_uart_c_on_ble_evt().
@@ -50,7 +42,7 @@
 /**@brief uart Client event type. */
 typedef enum
 {
-    BLE_UART_C_EVT_DISCOVERY_COMPLETE = 1,  /**< Event indicating that the Heart Rate Service has been discovered at the peer. */
+    BLE_UART_C_EVT_DISCOVERY_COMPLETE = 1,  /**< Event indicating that the Nordic UART Service (NUS) has been discovered at the peer. */
     BLE_UART_C_EVT_RX_DATA_NOTIFICATION     /**< Event indicating that a notification of the NUS RX data characteristic has been received from the peer. */
 } ble_uart_c_evt_type_t;
 
@@ -61,14 +53,14 @@ typedef enum
  * @{
  */
 
-/**@brief Structure containing the heart rate measurement received from the peer. */
+/**@brief Structure containing the NUS RX data received from the peer. */
 typedef struct
 {
     uint8_t rx_data[20];  /**< RX Value. */
     uint8_t len; 
 } ble_uart_t;
 
-/**@brief Heart Rate Event structure. */
+/**@brief NUS Event structure. */
 typedef struct
 {
     ble_uart_c_evt_type_t evt_type;  /**< Type of the event. */

--- a/ble_app_uart_c/main.c
+++ b/ble_app_uart_c/main.c
@@ -572,7 +572,7 @@ static void uart_c_evt_handler(ble_uart_c_t * p_uart_c, ble_uart_c_evt_t * p_uar
             APP_ERROR_CHECK(err_code);
             break;
 
-        case BLE_UART_C_EVT_HRM_NOTIFICATION:
+        case BLE_UART_C_EVT_RX_DATA_NOTIFICATION:
         {
             for (uint32_t i = 0; i < p_uart_c_evt->params.uart.len; i++)
             {

--- a/ble_app_uart_c/main.c
+++ b/ble_app_uart_c/main.c
@@ -9,9 +9,9 @@
 
 /** @example Board/nrf6310/s120/experimental/ble_app_uart_c/main.c
  *
- * @brief BLE Heart Rate Collector application main file.
+ * @brief BLE Nordic UART service (NUS) client application main file.
  *
- * This file contains the source code for a sample heart rate collector.
+ * This file contains the source code for a sample Nordic UART service client.
  */
 
 #include <stdint.h>
@@ -197,7 +197,7 @@ static ret_code_t device_manager_event_handler(const dm_handle_t    * p_handle,
         }
         case DM_EVT_SECURITY_SETUP_COMPLETE:
         {    
-             // Heart rate service discovered. Enable notification of Heart Rate Measurement.
+            // Nordic UART service discovered. Enable notification of RX channel.
             err_code = ble_uart_c_rx_notif_enable(&m_ble_uart_c);
             APP_ERROR_CHECK(err_code);
             break;
@@ -554,7 +554,7 @@ static void power_manage(void)
 }
 
 
-/**@brief Heart Rate Collector Handler.
+/**@brief Nordic UART Service (NUS) Client Event Handler.
  */
 static void uart_c_evt_handler(ble_uart_c_t * p_uart_c, ble_uart_c_evt_t * p_uart_c_evt)
 {
@@ -567,7 +567,7 @@ static void uart_c_evt_handler(ble_uart_c_t * p_uart_c, ble_uart_c_evt_t * p_uar
             err_code = dm_security_setup_req(&m_dm_device_handle);
             APP_ERROR_CHECK(err_code);
             
-            // Heart rate service discovered. Enable notification of Heart Rate Measurement.
+            // Nordic UART service discovered. Enable notification of RX data channel.
             err_code = ble_uart_c_rx_notif_enable(p_uart_c);
             APP_ERROR_CHECK(err_code);
             break;
@@ -736,7 +736,7 @@ int main(void)
     printf("Scanning ...\r\n");
 	
     // Start scanning for peripherals and initiate connection
-    // with devices that advertise Heart Rate UUID.
+    // with devices that advertise NUS UUID.
     scan_start();
 
     for (;;)

--- a/ble_app_uart_c/main.c
+++ b/ble_app_uart_c/main.c
@@ -562,7 +562,7 @@ static void uart_c_evt_handler(ble_uart_c_t * p_uart_c, ble_uart_c_evt_t * p_uar
 
     switch (p_uart_c_evt->evt_type)
     {
-        case BLE_uart_C_EVT_DISCOVERY_COMPLETE:
+        case BLE_UART_C_EVT_DISCOVERY_COMPLETE:
             // Initiate bonding.
             err_code = dm_security_setup_req(&m_dm_device_handle);
             APP_ERROR_CHECK(err_code);


### PR DESCRIPTION
Hi,

There are 5 fixes in this pull request. Commit cfede64 is critical, whereas others are optional.

About commit cfede64:
Commit cfede64 fixed a bug, the scenario is described below:
- If ble_uart_c_write_string() is called before connection handle is valid, the message is still enqueued in TX buffer.
- However, when the message is de-queued in tx_buffer_process(), sd_ble_gattc_write() returns error, so that buffer index m_tx_index is not manipulated.
- This messes up the TX buffer.

What commit cfede64 does is to avoid en-queuing messages to TX buffer when BLE connection is not made. Therefore, m_tx_index is not messed up anymore.

Thank you for your attention.

Regards,
P.K.Chan
